### PR TITLE
Switch var type from string to File

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ After installation and configuration of Cromwell (if that is your preferred inte
 
 For additional information about writing, reading and using CWL files, see the [official CWL user guide](https://www.commonwl.org/user_guide/).
 
-To help ensure proper installation and setup, example files (sample bam, matched control bam, healthy bam, targeted regions bed, blacklist bed, low complexity regions bed) are located in the `example_data` folder. In order to run these files with the SV pipeline, the hg19 reference genome and annotation is also needed (see instructions at the bottom of this page for installation). If run correctly, the output from the SV pipeline should be consistent with the output file at `example_data/example.out.bedpe` which describes a single translocation between chromosomes 10 and 13. The `example_ymls/sv_example.yml` can be used to run this analysis, but filepaths in the yml will need to be updated to reflect your PACT installation and the locations of your genome reference and annotation data.
+To help ensure proper installation and setup, example files (sample bam, matched control bam, healthy bam, targeted regions bed, blacklist bed, low complexity regions bed) are located in the `example_data` folder. Note that due to file size, `git lfs` may be required for download. In order to run these files with the SV pipeline, the hg19 reference genome and annotation is also needed (see instructions at the bottom of this page for installation). If run correctly, the output from the SV pipeline should be consistent with the output file at `example_data/example.out.bedpe` which describes a single translocation between chromosomes 10 and 13. The `example_ymls/sv_example.yml` can be used to run this analysis, but filepaths in the yml will need to be updated to reflect your PACT installation and the locations of your genome reference and annotation data.
 
 ## Structure
 
@@ -50,7 +50,7 @@ Common/required inputs are described below, including how to label the informati
   
   | Input label | Applicable workflow(s) | Description |
   | --- | --- | --- |
-  | reference | All workflows (required) | Absolute path to a reference genome fasta file. A <reference>.fai index file made using `samtools faidx` and a <reference>.dict file made using Picard's `CreateSequenceDictionary` command should be present in the directory. |
+  | reference | All workflows (required) | Reference genome fasta file. A <reference>.fai index file made using `samtools faidx` and a <reference>.dict file made using Picard's `CreateSequenceDictionary` command should be present in the directory. |
   | ref_genome | SV and CNA workflows (required) | Name of reference genome used. Should match the name used by any applicable annotation databases (eg. hg19) |
   | ref_flat | CNA workflow (required) | Genome annotation file in refFlat format |
 </details>
@@ -59,8 +59,8 @@ Common/required inputs are described below, including how to label the informati
 
   | Input label | Applicable workflow(s) | Description |
   | --- | --- | --- |
-  | snpEff_data | SV workflow (required) | Absolute path to a snpEff annotation database directory. This can be downloaded using snpEff's download command: `java -jar snpEff.jar download <database>`. |
-  | vep_cache_dir | SNV workflow (required) | Absolute path to vep annotation cache information. See the ensembl website (https://useast.ensembl.org/info/docs/tools/vep/script/vep_cache.html) for information about downloading the cache. |
+  | snpEff_data | SV workflow (required) | snpEff annotation database directory. This can be downloaded using snpEff's download command: `java -jar snpEff.jar download <database>`. |
+  | vep_cache_dir | SNV workflow (required) | vep annotation cache information. See the ensembl website (https://useast.ensembl.org/info/docs/tools/vep/script/vep_cache.html) for information about downloading the cache. |
   | vep_ensembl_assembly | SNV workflow (required) | A string containing the name of the genome assembly associated with the provided vep cache (eg GRCh37) |
   | vep_ensembl_version | SNV workflow (required) | A string containing the version number of the provided cache (eg 106) |
   | all_genes | CNA workflow (required) | Bed file of all annotated genes. First three columns are standard bed format, 4th column has gene name, 5th column has score value (arbitrary number, is not used), 6th column has +/- strand. No headed is expcted. |
@@ -82,9 +82,9 @@ Common/required inputs are described below, including how to label the informati
 
   | Input label | Applicable workflow(s) | Description |
   | --- | --- | --- |
-  | sample_bams | All workflows (required) | An array of paths to bam files that contain reads generated from targeted sequencing of cfDNA. Arrays can be provided in the input .yaml file as described by the (CWL user guide) or as shown in our example input .yamls |
-  | matched_control_bams | All workflows (required) | An array of paths to matched control bam files. The order of the array should be the same order as the sample_bams array (eg the `nth` entry in both arrays should correspond to the `nth` patient) |
-  | panel_of_normal_bams | All workflows (required) | An array of paths to bam files containing reads from healthy, normal samples sequenced using the same targeted panel used on the samples/matched controls. If such a panel is unavailable, this panel can instead be composed of any available matched control samples. |
+  | sample_bams | All workflows (required) | An array of bam files that contain reads generated from targeted sequencing of cfDNA. Arrays can be provided in the input .yaml file as described by the (CWL user guide) or as shown in our example input .yamls |
+  | matched_control_bams | All workflows (required) | An array of matched control bam files. The order of the array should be the same order as the sample_bams array (eg the `nth` entry in both arrays should correspond to the `nth` patient) |
+  | panel_of_normal_bams | All workflows (required) | An array of bam files containing reads from healthy, normal samples sequenced using the same targeted panel used on the samples/matched controls. If such a panel is unavailable, this panel can instead be composed of any available matched control samples. |
 </details>
   
   

--- a/example_ymls/cna_example.yml
+++ b/example_ymls/cna_example.yml
@@ -1,27 +1,37 @@
 # Path to reference genome fasta
-reference: /path/to/genome/reference.fa
+reference:
+ class: File
+ path:  /path/to/genome/reference.fa
 # Path to capture targets used by the targeted panel
-capture_targets: /path/to/capture_targets.bed
+capture_targets:
+ class: File
+ path:  /path/to/capture_targets.bed
 # Genome annotation file in refFlat format
-ref_flat: /path/to/genome/annotation/refFlat.txt
+ref_flat:
+ class: File
+ path: /path/to/genome/annotation/refFlat.txt
 # Name of genome (only hg19 and hg38 are supported)
 ref_genome: hg19
 # Path to bed file of genes targetd by the panel
 # Columns: 1=chromosome, 2=start, 3=end, 4=gene name, 5=description. Copy number control genes should be labeled 'CN-control'. A header line is expected
-target_genes: /path/to/file/of/targeted/genes.bed
+target_genes:
+ class: File
+ path: /path/to/file/of/targeted/genes.bed
 # Path to bed file of all annotated genes
 # Columns: 1=chromosome, 2=start, 3=end, 4=gene name, 5=score (arbitrary value, not used), 6= +/-
-all_genes: /path/to/list/of/all/annotated/genes.bed
+all_genes:
+ class: File
+ path: /path/to/list/of/all/annotated/genes.bed
 # Paths to cfDNA sample bam files
 sample_bams:
- - /path/to/patient1_cfDNA_sample.bam
- - /path/to/patient2_cfDNA_sample.bam
+ - {class: File, path: /path/to/patient1_cfDNA_sample.bam}
+ - {class: File, path: /path/to/patient2_cfDNA_sample.bam}
 # Paths to matched controls. Should be in same order as sample_bams
 matched_control_bams:
- - /path/to/patient1_matched_control.bam
- - /path/to/patient2_matched_control.bam
+ - {class: File, path: /path/to/patient1_matched_control.bam}
+ - {class: File, path: /path/to/patient2_matched_control.bam}
 # Paths to samples for the panel of healthy normals
 panel_of_normal_bams:
- - /path/to/healthy1_sample.bam
- - /path/to/healthy2_sample.bam
- - /path/to/healthy3_sample.bam
+ - {class: File, path: /path/to/healthy1_sample.bam}
+ - {class: File, path: /path/to/healthy2_sample.bam}
+ - {class: File, path: /path/to/healthy3_sample.bam}

--- a/example_ymls/snv_example.yml
+++ b/example_ymls/snv_example.yml
@@ -1,30 +1,34 @@
 # For use with snv_indel_pipeline.cwl
 # Reference should have .dict and .fai files in same directory
-reference: /path/to/hg19.fa
+reference:
+ class: File
+ path: /path/to/hg19.fa
 # Standard bed file of targeted regions during sequencing
 target_regions:
  class: File
  path: /path/to/targets.bed
 # Paths to cfDNA samples
 sample_bams:
- - /path/to/patient1_cfDNA_sample.bam
- - /path/to/patient2_cfDNA_sample.bam
+ - {class: File, path: /path/to/patient1_cfDNA_sample.bam}
+ - {class: File, path: /path/to/patient2_cfDNA_sample.bam}
 # Paths to matched control samples (ex: plasma depleted whole blood)
 # Should be in same order as sample bams
 matched_control_bams:
- - /path/to/patient1_matched_control.bam
- - /path/to/patient2_matched_control.bam
+ - {class: File, path: /path/to/patient1_matched_control.bam}
+ - {class: File, path: /path/to/patient2_matched_control.bam}
 # Paths to bams that make up the panel of normals
 panel_of_normal_bams:
- - /path/to/healthy1_sample.bam
- - /path/to/healthy2_sample.bam
- - /path/to/healthy3_sample.bam
+ - {class: File, path: /path/to/healthy1_sample.bam}
+ - {class: File, path: /path/to/healthy2_sample.bam}
+ - {class: File, path: /path/to/healthy3_sample.bam}
 # VCF of whitelisted SNV variants
 whitelist_vcf:
  class: File
  path: /path/to/whitelist.sort.vcf.gz
 # A local copy of a downloaded VEP cache is required for annotation
 # This can be passed as a "class: Directory" or simply as a string (recommended if saved locally)
-vep_cache_dir: /path/to/vep_cache
+vep_cache_dir: 
+ class: Directory
+ path: /path/to/vep_cache
 vep_ensembl_assembly: GRCh37
 vep_ensembl_version: 100

--- a/example_ymls/sv_example.yml
+++ b/example_ymls/sv_example.yml
@@ -1,6 +1,8 @@
 # For use with pipelines/sv_pipeline.cwl
 # Reference should have .dict and .fai files in same directory
-reference: /path/to/hg19.fa
+reference:
+ class: File
+ path: /path/to/hg19.fa
 ref_genome: hg19
 # snpEff database. These can be downloaded using java -jar snpEff.jar download <database>.
 # Should correspond to reference genome
@@ -9,14 +11,14 @@ snpEff_data:
  path: /path/to/snpEff/data/hg19
 # Paths to cfDNA samples
 sample_bams:
- - /path/to/PACT/example_data/example.sample.bam
+ - {class: File, path: /path/to/PACT/example_data/example.sample.bam}
 # Paths to matched control samples (ex: plasma depleted whole blood)
 # Should be in same order as sample_bams
 matched_control_bams:
- - /path/to/PACT/example_data/example.matchedControl.bam
+ - {class: File, path: /path/to/PACT/example_data/example.matchedControl.bam}
 # Paths to bams that make up the panel of normals.
 panel_of_normal_bams:
- - /path/to/PACT/example_data/example.healthy.bam
+ - {class: File, path: /path/to/PACT/example_data/example.healthy.bam}
 # Standard bed file of targeted regions during sequencing
 target_regions:
  class: File

--- a/pipelines/cna_pipeline.cwl
+++ b/pipelines/cna_pipeline.cwl
@@ -15,41 +15,35 @@ requirements:
 
 inputs:
  reference:
-  type:
-      - string
-      - File
+  type: File
+  secondaryFiles: [.fai]
   doc: "Reference genome fasta."
  capture_targets:
-  type:
-      - string
-      - File
+  type: File
   doc: "Bed file of probes used to target desired target regions. Can be supplied as file path or File"
  ref_flat:
-  type:
-      - string
-      - File
+  type: File
   doc: "refFlat file for reference genome"
  sample_bams:
-  type: string[]
-  doc: "Array of absolute paths to bam files. Contains cfDNA/plasma samples. Should have .bai files in same directory"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Array of bam files. Contains cfDNA/plasma samples. Should have .bai files in same directory"
  matched_control_bams:
-  type: string[]
-  doc: "Array of absolute paths to bam files. Should be in the same order as sample_bams (ie the nth sample in each array are matched)."
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Array of bam files. Should be in the same order as sample_bams (ie the nth sample in each array are matched)."
  panel_of_normal_bams:
-  type: string[]
-  doc: "Array of absolute paths to bams used as unmatched, panel of normals. Should have .bai files in same directory"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Array of bams used as unmatched, panel of normals. Should have .bai files in same directory"
  ref_genome:
   type: string
   doc: "hg19 or hg38. Other genomes not supported"
  target_genes:
-  type:
-      - string
-      - File
+  type: File
   doc: "Tab delimited bed file describing genes included in the targeted panel, including controls. Columns should contain: chromosome, start position, end position, gene name, description (can be anything, unless it is a control gene, in which case it should be labeled CN-control)"
  all_genes:
-  type:
-      - string
-      - File
+  type: File
   doc: "Bed file of all genes. Columns: chrom, start, stop, gene name, value (arbitrary), strand (+/-)"
  nsd:
   type: int?

--- a/pipelines/snv_indel_pipeline.cwl
+++ b/pipelines/snv_indel_pipeline.cwl
@@ -18,20 +18,20 @@ requirements:
 
 inputs:
  reference:
-  type: 
-      - string
-      - File
+  type: File
   secondaryFiles: [.fai, ^.dict]
-  doc: "Absolute path to reference.fa. Should have reference.dict and .fai files in the same directory"
+  doc: "reference.fa. Should have reference.dict and .fai files in the same directory"
  sample_bams:
-  type: string[]
-  doc: "Array of absolute paths to bam files. Contains cfDNA/plasma samples. Should have .bai files in same directory"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Contains cfDNA/plasma samples. Should have .bai files in same directory"
  matched_control_bams:
-  type: string[]
-  doc: "Array of absolute paths to bam files. Should be in the same order as sample_bams (ie the nth sample in each array are matches). Should have .bai files in same directory"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Should be in the same order as sample_bams (ie the nth sample in each array are matches). Should have .bai files in same directory"
  panel_of_normal_bams:
-  type: string[]
-  doc: "Array of absolute paths to bams used as an unmatched, panel of normals.  Should have accompanying .bai files"
+  type: File[]
+  doc: "unmatched, panel of normals.  Should have accompanying .bai files"
  target_regions:
   type: File
   doc: "Bed file of target regions"
@@ -80,9 +80,7 @@ inputs:
   default: false
   doc: "Determines whether variants found only via genotyping of whitelist sites will be filtered (as WHITELIST_ONLY) or passed through as variant calls."
  vep_cache_dir:
-  type:
-         - string
-         - Directory
+  type: Directory
   doc: "Cache directory downloaded for use with Vep annotation tool"
  vep_ensembl_assembly:
   type: string

--- a/pipelines/snv_indel_post_processing.cwl
+++ b/pipelines/snv_indel_post_processing.cwl
@@ -17,16 +17,17 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     sample_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     matched_control_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     panel_of_normal_bams:
-        type: string[]
+        type: File[]
+        secondaryFiles: [.bai]
     roi_intervals: 
         type: File
         doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
@@ -70,9 +71,7 @@ inputs:
         default: false
         doc: "Determines whether variants found only via genotyping of whitelist sites will be filtered (as WHITELIST_ONLY) or passed through as variant calls"
     vep_cache_dir:
-        type:
-            - string
-            - Directory
+        type: Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/pipelines/sv_pipeline.cwl
+++ b/pipelines/sv_pipeline.cwl
@@ -19,9 +19,7 @@ requirements:
 
 inputs:
  reference:
-  type: 
-      - string
-      - File
+  type: File
   secondaryFiles: [.fai, ^.dict]
   doc: "Absolute path to reference.fa. Should have reference.dict and .fai files in the same directory"
  ref_genome:
@@ -31,14 +29,17 @@ inputs:
   type: Directory
   doc: "snpEff db. Example: /location/of/database/hg19"
  sample_bams:
-  type: string[]
-  doc: "Array of absolute paths to bam files. Contains cfDNA/plasma samples. Should have .bai files in same directory"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Array of bam files. Contains cfDNA/plasma samples. Should have .bai files in same directory"
  matched_control_bams:
-  type: string[]
-  doc: "Array of absolute paths to bam files. Should be in the same order as sample_bams (ie the nth sample in each array are matches). Should have .bai files in same directory"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Array of bam files. Should be in the same order as sample_bams (ie the nth sample in each array are matches). Should have .bai files in same directory"
  panel_of_normal_bams:
-  type: string[]
-  doc: "Array of absolute paths to bams used as an unmatched, panel of normals.  Should have accompanying .bai files"
+  type: File[]
+  secondaryFiles: [.bai]
+  doc: "Array of bams used as an unmatched, panel of normals.  Should have accompanying .bai files"
  max_distance_to_merge:
   type: int?
   default: 100

--- a/subworkflows/cna_reference_coverage.cwl
+++ b/subworkflows/cna_reference_coverage.cwl
@@ -10,15 +10,14 @@ requirements:
 
 inputs:
  panel_of_normal_bams:
-  type: string[]
+  type: File[]
+  secondaryFiles: [.bai]
  targets:
   type: File
  anti_targets:
   type: File
  reference:
-  type:
-      - string
-      - File
+  type: File
 
 outputs:
   reference_coverage:

--- a/subworkflows/cnvkit_initial_analysis.cwl
+++ b/subworkflows/cnvkit_initial_analysis.cwl
@@ -11,15 +11,12 @@ requirements:
 
 inputs:
  bams:
-  type: string[]
+  type: File[]
+  secondaryFiles: [.bai]
  targets: 
-   type: 
-       - string
-       - File
+   type:  File
  anti_targets:
-   type:
-       - string
-       - File
+   type: File
  reference_coverage:
    type: File
 

--- a/subworkflows/cnvkit_prep_regions.cwl
+++ b/subworkflows/cnvkit_prep_regions.cwl
@@ -10,18 +10,12 @@ requirements:
 
 inputs:
  reference:
-  type:
-      - string
-      - File
-#  secondaryFiles: [.fai, ^.dict]
+  type: File
+  secondaryFiles: [.fai]
  ref_flat:
-  type:
-      - string
-      - File
+  type: File
  capture_targets:
-  type:
-      - string
-      - File
+  type: File
 
 outputs:
  targets:

--- a/subworkflows/filter_vcf.cwl
+++ b/subworkflows/filter_vcf.cwl
@@ -19,13 +19,12 @@ inputs:
     gnomad_field_name:
         type: string
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     do_cle_vcf_filter:
         type: boolean
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     filter_minimum_depth:
         type: int

--- a/subworkflows/fp_filter.cwl
+++ b/subworkflows/fp_filter.cwl
@@ -9,21 +9,20 @@ requirements:
 
 inputs:
     bam:
-        string
+        type: File
+        secondaryFiles: [.bai]
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     vcf:
         type: File
         secondaryFiles: [.tbi]
     variant_caller:
-        string
-    sample_name:
-        string?
-    min_var_freq:
-        float?
+        type: string
+    sample_name: 
+        type: string?
+    min_var_freq: 
+        type: float?
 
 outputs:
     unfiltered_vcf:

--- a/subworkflows/mutect.cwl
+++ b/subworkflows/mutect.cwl
@@ -11,14 +11,14 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     scatter_count:

--- a/subworkflows/pindel.cwl
+++ b/subworkflows/pindel.cwl
@@ -11,14 +11,14 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     insert_size:

--- a/subworkflows/pindel_cat.cwl
+++ b/subworkflows/pindel_cat.cwl
@@ -9,14 +9,14 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     region_file:
         type: File
     insert_size:

--- a/subworkflows/process_cnvkit_results.cwl
+++ b/subworkflows/process_cnvkit_results.cwl
@@ -23,13 +23,9 @@ inputs:
  genome:
   type: string
  target_genes:
-  type:
-      - string
-      - File
+  type: File
  all_genes:
-  type:
-      - string
-      - File
+  type: File
 
 outputs:
  segmented_beds:

--- a/subworkflows/strelka_and_post_processing.cwl
+++ b/subworkflows/strelka_and_post_processing.cwl
@@ -11,13 +11,13 @@ requirements:
 
 inputs:
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     interval_list:
         type: File

--- a/subworkflows/suppress_background_error.cwl
+++ b/subworkflows/suppress_background_error.cwl
@@ -12,12 +12,11 @@ inputs:
     vcf:
         type: File
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     panel_of_normal_bams:
-        type: string[]
+        type: File[]
+        secondaryFiles: [.bai]
     roi_intervals:
         type: File
 

--- a/subworkflows/sv_caller.cwl
+++ b/subworkflows/sv_caller.cwl
@@ -11,14 +11,15 @@ requirements:
 
 inputs:
  reference:
-  type:
-      - string
-      - File
+  type: File
   secondaryFiles: [.fai, ^.dict]
  sample_bams:
-  type: string[]
+  type: File[]
+  secondaryFiles: [.bai]
  matched_control_bams:
-  type: string[]
+  type:
+      - File[]
+  secondaryFiles: [.bai]
  minwt:
   type: int
 

--- a/subworkflows/sv_merge_and_filter.cwl
+++ b/subworkflows/sv_merge_and_filter.cwl
@@ -34,11 +34,14 @@ inputs:
   type: boolean?
   default: true
  sample_bams:
-   type: string[]
+   type: File[]
+   secondaryFiles: [.bai]
  matched_control_bams:
-   type: string[]
+   type: File[]
+   secondaryFiles: [.bai]
  panel_of_normal_bams:
-   type: string[]
+   type: File[]
+   secondaryFiles: [.bai]
  target_regions:
   type: File
  neither_region:

--- a/subworkflows/varscan.cwl
+++ b/subworkflows/varscan.cwl
@@ -6,14 +6,14 @@ label: "varscan somatic workflow"
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     roi_bed:
         type: File?
     strand_filter:

--- a/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/subworkflows/varscan_pre_and_post_processing.cwl
@@ -12,14 +12,14 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     strand_filter:

--- a/subworkflows/whitelist.cwl
+++ b/subworkflows/whitelist.cwl
@@ -8,14 +8,14 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
     whitelist_vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/tools/bam_readcount.cwl
+++ b/tools/bam_readcount.cwl
@@ -137,14 +137,13 @@ inputs:
         inputBinding:
             position: -7
     reference_fasta:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: -6
     bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: -5
     prefix:

--- a/tools/bed_to_interval.cwl
+++ b/tools/bed_to_interval.cwl
@@ -20,9 +20,7 @@ inputs:
    prefix: "I="
    separate: false
  sd:
-  type:
-      - string
-      - File
+  type: File
   secondaryFiles: [^.dict, .fai]
   inputBinding:
    position: 3

--- a/tools/cna_calls.cwl
+++ b/tools/cna_calls.cwl
@@ -34,9 +34,7 @@ inputs:
   inputBinding:
    position: 2
  target_genes:
-  type:
-      - string
-      - File
+  type: File
   inputBinding:
    position: 3
  nsd:

--- a/tools/cnvkit_access_regions.cwl
+++ b/tools/cnvkit_access_regions.cwl
@@ -18,10 +18,8 @@ arguments:
 
 inputs:
  reference:
-  type:
-      - string
-      - File
-#  secondaryFiles: [.fai, ^.dict]
+  type: File
+  secondaryFiles: [.fai, ^.dict]
   inputBinding:
       position: 2
 

--- a/tools/cnvkit_antitarget.cwl
+++ b/tools/cnvkit_antitarget.cwl
@@ -15,9 +15,7 @@ requirements:
 
 inputs:
  capture_targets:
-  type:
-   - string
-   - File
+  type: File
   inputBinding:
    position: 1
 

--- a/tools/cnvkit_coverage.cwl
+++ b/tools/cnvkit_coverage.cwl
@@ -15,13 +15,12 @@ requirements:
 
 inputs:
     bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 1
     bed:
-        type:
-            - string
-            - File
+        type: File
         inputBinding:
             position: 2
     istarget:
@@ -30,7 +29,7 @@ inputs:
 arguments:
  - valueFrom: |
     ${
-      var x = String(inputs.bam).split('/').slice(-1)[0].split('.')[0]
+      var x = String(inputs.bam.nameroot)
       var suffix = "";
       if (inputs.istarget) {
         suffix = ".targetcoverage.cnn";

--- a/tools/cnvkit_reference.cwl
+++ b/tools/cnvkit_reference.cwl
@@ -50,9 +50,7 @@ requirements:
 
 inputs:
  reference:
-  type:
-   - string
-   - File
+  type: File
   inputBinding:
    position: 3
  target_cnn:

--- a/tools/cnvkit_target.cwl
+++ b/tools/cnvkit_target.cwl
@@ -15,16 +15,12 @@ requirements:
 
 inputs:
  capture_targets:
-  type:
-   - string
-   - File
+  type: File
   inputBinding:
    position: 1
 
  ref_flat:
-  type:
-   - string
-   - File
+  type: File
   inputBinding:
    position: 2
    prefix: "--annotate" 

--- a/tools/delly_caller.cwl
+++ b/tools/delly_caller.cwl
@@ -17,27 +17,26 @@ requirements:
 
 inputs:
  ref:
-  type: 
-      - string
-      - File
+  type: File
   secondaryFiles: [.fai]
   inputBinding:
    prefix: -g
    position: 1
   doc: "Reference genome .fa"
  sample_bam:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
   inputBinding:
    position: 3
  normal_bam:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
   inputBinding:
    position: 4
-  secondaryFiles: [.bai]
 
 arguments:
  - prefix: -o
-   valueFrom: $(runtime.outdir)/$(inputs.sample_bam.split('/').slice(-1)[0].split('.').slice(0,-1).join('.')).bcf
+   valueFrom: $(runtime.outdir)/$(inputs.sample_bam.nameroot).bcf
    position: 2
 
 outputs:
@@ -45,6 +44,6 @@ outputs:
   type: File
   secondaryFiles: .csi
   outputBinding:
-   glob: $(inputs.sample_bam.split('/').slice(-1)[0].split('.').slice(0,-1).join('.')).bcf
+   glob: $(inputs.sample_bam.nameroot).bcf
 
 

--- a/tools/extract_sample_name_from_bam.cwl
+++ b/tools/extract_sample_name_from_bam.cwl
@@ -18,7 +18,7 @@ requirements:
 
 inputs:
  bam:
-  type: string
+  type: File
   inputBinding:
    position: 1
 

--- a/tools/filter_vcf_mapq0.cwl
+++ b/tools/filter_vcf_mapq0.cwl
@@ -20,13 +20,12 @@ inputs:
         inputBinding:
             position: 1
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 2
     reference: 
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 3

--- a/tools/filter_vcf_whitelist.cwl
+++ b/tools/filter_vcf_whitelist.cwl
@@ -112,11 +112,13 @@ inputs:
         inputBinding:
             position: -4
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: -3
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: -2
     filter_whitelist_variants:

--- a/tools/fp_filter.cwl
+++ b/tools/fp_filter.cwl
@@ -16,15 +16,14 @@ arguments:
     "--output", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf }]
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--reference"
             position: 1
     bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             prefix: "--bam-file"
             position: 2

--- a/tools/gatk_SelectVariants.cwl
+++ b/tools/gatk_SelectVariants.cwl
@@ -10,13 +10,13 @@ requirements:
       tmpdirMin: 25000
     - class: DockerRequirement
       dockerPull: "jbwebster/snv_pipeline_docker"
+
 arguments:
     ["-O", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf.gz }]
+
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"

--- a/tools/gatk_VariantFiltration.cwl
+++ b/tools/gatk_VariantFiltration.cwl
@@ -13,9 +13,8 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
+        secondaryFiles: [.fai]
         inputBinding:
             position: 1
             prefix: "-R"

--- a/tools/gatk_haplotype_caller_PoN.cwl
+++ b/tools/gatk_haplotype_caller_PoN.cwl
@@ -12,20 +12,16 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 1
             prefix: "-R"
     bams:
-        type:
-            type: array
-            items: string
-            inputBinding:
-                prefix: "-I"
+        type: File[]
+        secondaryFiles: [.bai]
         inputBinding:
+            prefix: "-I"
             position: 2
     vcf:
         type: File

--- a/tools/gene_overlap.cwl
+++ b/tools/gene_overlap.cwl
@@ -25,9 +25,7 @@ requirements:
 
 inputs:
  all_genes:
-  type:
-      - string
-      - File
+  type: File
   inputBinding:
    position: 1
  segmented_bed:

--- a/tools/lumpy_caller.cwl
+++ b/tools/lumpy_caller.cwl
@@ -16,9 +16,11 @@ requirements:
 
 inputs:
   sample_bam:
-   type: string
+   type: File
+   secondaryFiles: [".bai"]
   normal_bam:
-   type: string
+   type: File
+   secondaryFiles: [".bai"]
   splitters:
    type: File[]
    secondaryFiles: [".bai"]
@@ -42,8 +44,8 @@ inputs:
 arguments:
  - valueFrom: |
     ${
-      var x = inputs.sample_bam;
-      x = x + "," + inputs.normal_bam
+      var x = inputs.sample_bam.path;
+      x = x + "," + inputs.normal_bam.path;
       return(x)
     }
    position: 2
@@ -53,8 +55,8 @@ arguments:
  - prefix: -o
    valueFrom: |
     ${
-      var x = String(runtime.outdir) + "/" + String(inputs.sample_bam).split('/').slice(-1)[0].split('.').slice(0,-1).join('.') + ".vcf";
-      return(x)
+        var x = String(runtime.outdir) + "/" + inputs.sample_bam.nameroot + ".vcf";
+        return(x);
     }
    position: 5
      

--- a/tools/lumpy_prep.cwl
+++ b/tools/lumpy_prep.cwl
@@ -38,11 +38,13 @@ requirements:
 
 inputs:
  sample_bam:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
   inputBinding:
    position: 1
  normal_bam:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
   inputBinding:
    position: 2
 

--- a/tools/manta_caller.cwl
+++ b/tools/manta_caller.cwl
@@ -18,19 +18,19 @@ baseCommand: ["/usr/bin/python", "/usr/bin/manta/bin/configManta.py"]
 
 inputs:
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: -2
             prefix: "--normalBam"
     sample_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: -3
             prefix: "--tumorBam"
     ref:
-        type: 
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai]
         inputBinding:
             position: -4

--- a/tools/mutect.cwl
+++ b/tools/mutect.cwl
@@ -33,18 +33,18 @@ arguments:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 2
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 3
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 4
     interval_list:

--- a/tools/normalize_variants.cwl
+++ b/tools/normalize_variants.cwl
@@ -13,9 +13,7 @@ arguments:
     ["-O", { valueFrom: $(runtime.outdir)/normalized.vcf.gz }]
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"

--- a/tools/picard_merge_vcfs.cwl
+++ b/tools/picard_merge_vcfs.cwl
@@ -18,8 +18,7 @@ inputs:
         type: string?
         default: "merged"
     sequence_dictionary:
-        type:
-            - string
+        type: 
             - File
             - 'null'
         inputBinding:

--- a/tools/pindel.cwl
+++ b/tools/pindel.cwl
@@ -38,11 +38,13 @@ requirements:
 
 inputs:
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 1
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 2
     insert_size:
@@ -59,9 +61,7 @@ inputs:
         inputBinding:
             position: 5
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-f"

--- a/tools/pindel_somatic_filter.cwl
+++ b/tools/pindel_somatic_filter.cwl
@@ -17,9 +17,7 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
     pindel_output_summary:
         type: File

--- a/tools/process_cnvkit_results.cwl
+++ b/tools/process_cnvkit_results.cwl
@@ -48,9 +48,7 @@ inputs:
   inputBinding:
    position: 7
  target_genes:
-  type:
-      - string
-      - File
+  type: File
   inputBinding:
    position: 8
 

--- a/tools/single_svtyper_genotyping.cwl
+++ b/tools/single_svtyper_genotyping.cwl
@@ -19,7 +19,8 @@ inputs:
    position: 2
   doc: "VCF file of SVs to genotype"
  bam:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
   inputBinding:
    position: 3
   doc: "Bam to use for genotyping"

--- a/tools/strelka.cwl
+++ b/tools/strelka.cwl
@@ -10,26 +10,28 @@ requirements:
         ramMin: 4000
     DockerRequirement:
       dockerPull: "jbwebster/snv_pipeline_docker"
+
 arguments:
     [ { valueFrom: $(inputs.cpu_reserved), position: 1 },
       { valueFrom: $(runtime.outdir), position: 2 }]
+
 inputs:
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             prefix: '--tumorBam='
             separate: false
             position: 3
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             prefix: '--normalBam='
             separate: false
             position: 4
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: '--referenceFasta='

--- a/tools/svtyper_genotyping.cwl
+++ b/tools/svtyper_genotyping.cwl
@@ -19,15 +19,17 @@ inputs:
    position: 2
   doc: "VCF file of SVs to genotype"
  bam_one:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
  bam_two:
-  type: string
+  type: File
+  secondaryFiles: [.bai]
 
 arguments:
  - valueFrom: |
     ${
-      var x = inputs.bam_one;
-      x = x + "," + inputs.bam_two;
+      var x = inputs.bam_one.path;
+      x = x + "," + inputs.bam_two.path;
       return(x)
     }
    position: 3

--- a/tools/variants_to_table.cwl
+++ b/tools/variants_to_table.cwl
@@ -19,9 +19,7 @@ arguments:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"

--- a/tools/varscan_process_somatic.cwl
+++ b/tools/varscan_process_somatic.cwl
@@ -8,6 +8,7 @@ arguments: [
     { valueFrom: " && ", shellQuote: false },
     "java", "-jar", "/usr/local/bin/Varscan.jar", "processSomatic"
 ]
+
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
@@ -15,6 +16,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: StepInputExpressionRequirement
+
 inputs:
     variants:
         type: File

--- a/tools/varscan_somatic.cwl
+++ b/tools/varscan_somatic.cwl
@@ -61,17 +61,17 @@ requirements:
 
 inputs:
     tumor_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 1
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 2
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 3

--- a/tools/vep.cwl
+++ b/tools/vep.cwl
@@ -29,9 +29,7 @@ inputs:
             prefix: "-i"
             position: 1
     cache_dir:
-        type:
-            - string
-            - Directory
+        type: Directory
         inputBinding:
             prefix: "--dir"
             position: 4
@@ -57,10 +55,7 @@ inputs:
             separate: false
             position: 6
     reference:
-        type:
-            - "null"
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--fasta" 

--- a/tools/whitelist_gatk_haplotype_caller.cwl
+++ b/tools/whitelist_gatk_haplotype_caller.cwl
@@ -41,18 +41,18 @@ requirements:
 
 inputs:
     reference:
-        type:
-            - string
-            - File
+        type: File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 1
     normal_bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 2
     bam:
-        type: string
+        type: File
+        secondaryFiles: [.bai]
         inputBinding:
             position: 3
     whitelist_vcf:


### PR DESCRIPTION
To be consistent with CWL gold standards, all input files must be passed as 'class: File' rather than simply as strings.